### PR TITLE
bugfix buildOrLawLinks.js (59:16 - missing parens)

### DIFF
--- a/content/buildOrLawLinks.js
+++ b/content/buildOrLawLinks.js
@@ -56,7 +56,7 @@ class OrLawsDisplay {
         "fifth",
         "sixth",
       ].findIndex((ordinal) => {
-        return RegExp(`${ordinal}\\sspecial\\ssession)[^]`).test(
+        return RegExp(`(${ordinal}\\sspecial\\ssession)[^]`).test(
           text.toLowerCase()
         );
       });


### PR DESCRIPTION
fixes missing paren when looking for special session laws.